### PR TITLE
Remove tree-sitter from build to clear up space

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -166,7 +166,6 @@ const extensionConfig = {
 	sourcemap: !production,
 	logLevel: "silent",
 	plugins: [
-		copyWasmFiles,
 		copyLocalesFiles,
 		/* add to the end of plugins array */
 		esbuildProblemMatcherPlugin,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "roo-scheduler",
-	"version": "0.0.1",
+	"version": "0.0.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "roo-scheduler",
-			"version": "0.0.1",
+			"version": "0.0.8",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.10.2",
 				"@anthropic-ai/sdk": "^0.37.0",


### PR DESCRIPTION
## Context

Removes 40MB from vsix build

## Implementation

Removed tree sitter files form esbuild

