### PR TITLE
Fix default start date issue and next execution calculating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [0.0.10] - 2025-04-25
+
+### Fixed
+- Resolved an issue where `startDate` was set by default.
+
+### Changed
+- Updated scheduling logic for interval-based tasks:
+  - **If a start date/time is specified:** Intervals are now calculated from the original start time. For example, for an hourly task with a start time of 10:00am, if execution is delayed (e.g., due to inactivity or the computer being off/in deep sleep) and the task runs at 10:15am, the next execution is scheduled for 11:00am.
+  - **If no start time is specified:** The interval is calculated from the last execution time. For example, if the last execution was at 10:15am, the next execution will be at 11:15am.
+- Updated "Usage Tips" in the README

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Roo Scheduler connects with [Roo Code](https://roocode.com/)'s extension points 
 - **Codebase Analysis**: Run periodic analysis to identify optimization opportunities
 - **Custom Workflows**: Automate any repetitive development task with natural language instructions (tests, memory bank, MCP etc)
 
+## Usage Tips
+
+- Currently, this extension will not wake up your computer to run a task.  It will run tasks if the screen is locked.  When VS Code “wakes up,” either when a computer starts or another background process is run, then any pending tasks will be run.
+- Intervals are calculated differently depending on if start date time is specified.  For example, for an hourly task, if I have start date/time specified at 10:00am and the execution is delayed until 10:15am due to inactivity interruption delays or the computer being off/asleep, then the next task is scheduled for 11:00am. If I don’t specify start time, the hour interval is calculated from the last execution time, so the next execution will be 11:15am
+
 ## License
 
 [Apache 2.0 © 2025 Roo Scheduler](./LICENSE)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Roo Scheduler",
 	"description": "A task scheduler for Roo Code",
 	"publisher": "KyleHoskins",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"icon": "assets/icons/scheduler-icon.png",
 	"galleryBanner": {
 		"color": "#617A91",

--- a/src/services/scheduler/SchedulerService.ts
+++ b/src/services/scheduler/SchedulerService.ts
@@ -228,7 +228,7 @@ export class SchedulerService {
 
     const now = new Date();
     const startDateTime = new Date(
-      `${schedule.startDate || new Date().toISOString().split('T')[0]}T${schedule.startHour || '00'}:${schedule.startMinute || '00'}:00`
+      `${schedule.startDate || new Date().toISOString().split('T')[0]}T${schedule.startDate ? schedule.startHour : new Date().getHours().toString().padStart(2, '0')}:${schedule.startMinute || '00'}:00`
     );
 
 
@@ -244,7 +244,10 @@ export class SchedulerService {
     // Determine the most recent reference time (lastExecutionTime, lastSkippedTime, or startDateTime)
     let referenceTime: Date;
     
-    if (schedule.lastExecutionTime || schedule.lastSkippedTime) {
+    // If startDate was configured, we want our intervals based on that 
+    // (ex: keep running on the hour even if the last execution was delayed 5 minutes)
+    // Otherwise, we want to set based on execution or skip time
+    if ((schedule.lastExecutionTime || schedule.lastSkippedTime) && !schedule.startDate) {
       // Find the most recent of lastExecutionTime and lastSkippedTime
       const lastExecutionDate = schedule.lastExecutionTime ? new Date(schedule.lastExecutionTime) : new Date(0);
       const lastSkippedDate = schedule.lastSkippedTime ? new Date(schedule.lastSkippedTime) : new Date(0);
@@ -377,8 +380,8 @@ export class SchedulerService {
         // Move to next day
         nextTime.setDate(nextTime.getDate() + 1);
         // Reset to the specified time
-        nextTime.setHours(parseInt(schedule.startHour || '0'));
-        nextTime.setMinutes(parseInt(schedule.startMinute || '0'));
+          nextTime.setHours(parseInt(schedule.startHour || '0'));
+          nextTime.setMinutes(parseInt(schedule.startMinute || '0'));
         nextTime.setSeconds(0);
         
         daysChecked++;

--- a/webview-ui/src/components/scheduler/ScheduleForm.tsx
+++ b/webview-ui/src/components/scheduler/ScheduleForm.tsx
@@ -244,9 +244,9 @@ const ScheduleForm = forwardRef<ScheduleFormHandle, ScheduleFormProps>(
 				console.error("Expiration time must be after start time")
 				return
 			}
-
+	
 			let formToSave = form
-
+	
 			// If hasExpiration is false, clear expiration fields
 			if (!hasExpiration) {
 				formToSave = {
@@ -256,7 +256,17 @@ const ScheduleForm = forwardRef<ScheduleFormHandle, ScheduleFormProps>(
 					expirationMinute: "00",
 				}
 			}
-
+	
+			// If hasStartDate is false, clear start date fields
+			if (!hasStartDate) {
+				formToSave = {
+					...formToSave,
+					startDate: "",
+					startHour: "",
+					startMinute: "00",
+				}
+			}
+	
 			// If hasDaysOfWeek is false, set all days to be selected
 			if (!hasDaysOfWeek) {
 				formToSave = {
@@ -264,7 +274,7 @@ const ScheduleForm = forwardRef<ScheduleFormHandle, ScheduleFormProps>(
 					selectedDays: { ...allDaysSelected },
 				}
 			}
-
+	
 			onSave(formToSave)
 		}
 


### PR DESCRIPTION
### Fixed
- Resolved an issue where `startDate` was set by default.

### Changed
- Updated scheduling logic for interval-based tasks:
  - **If a start date/time is specified:** Intervals are now calculated from the original start time. For example, for an hourly task with a start time of 10:00am, if execution is delayed (e.g., due to inactivity or the computer being off/in deep sleep) and the task runs at 10:15am, the next execution is scheduled for 11:00am.
  - **If no start time is specified:** The interval is calculated from the last execution time. For example, if the last execution was at 10:15am, the next execution will be at 11:15am.
- Updated "Usage Tips" in the README